### PR TITLE
Fix check to actually read the primary-replica query result

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,5 +65,26 @@ func main() {
 			fmt.Fprintf(os.Stderr, "rows.Close() error: %v\n", err)
 		}
 	}()
+
+	if !rows.Next() {
+		fmt.Printf("server %s: no result from fn_hadr_is_primary_replica (not in an availability group?)\n", server)
+		os.Exit(1)
+	}
+
+	var isPrimary sql.NullInt64
+	if err := rows.Scan(&isPrimary); err != nil {
+		fmt.Println("Failed to read query result: ", err.Error())
+		os.Exit(1)
+	}
+	if err := rows.Err(); err != nil {
+		fmt.Println("Error iterating query result: ", err.Error())
+		os.Exit(1)
+	}
+
+	if !isPrimary.Valid || isPrimary.Int64 != 1 {
+		fmt.Printf("server %s is not primary\n", server)
+		os.Exit(1)
+	}
+
 	fmt.Printf("server %s is primary\n", server)
 }


### PR DESCRIPTION
## Summary
- `main.go` ran `SELECT sys.fn_hadr_is_primary_replica(...)` but never called `rows.Next()`/`rows.Scan()` on the result. `db.Query` only errors on execution failure, so **any reachable replica (primary or secondary) passed the check and was reported as primary**, as long as the query ran successfully.
- Haproxy uses this check's exit code to decide which MSSQL node to route as primary, so this could route write traffic to a read-only secondary.

## Fix
- Read the returned value into a `sql.NullInt64` (the function can return `NULL` if the database isn't in an Availability Group).
- Exit 0 (and print "is primary") only when the value is exactly `1`.
- Exit 1 in every other case: no row, `NULL`, `0`, or a scan/iteration error.

## Test plan
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go build .` succeeds
- [ ] Manually verify exit code against a real primary and a real secondary replica (needs a live MSSQL AG — not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)